### PR TITLE
Invariant Endo instance, bump contravariant upper version bounds

### DIFF
--- a/Data/Functor/Invariant.hs
+++ b/Data/Functor/Invariant.hs
@@ -91,7 +91,7 @@ instance Invariant2 Const where invmap2 f _ _ _ (Const x) = Const (f x)
 instance Arrow arr => Invariant2 (WrappedArrow arr) where
   invmap2 _ f' g _ (WrapArrow x) = WrapArrow $ arr g Cat.. x Cat.. arr f'
 
-
+-- | @Data.Monoid@
 instance Invariant Endo where
   invmap f g (Endo x) = Endo (f . x . g)
 

--- a/Data/Functor/Invariant.hs
+++ b/Data/Functor/Invariant.hs
@@ -12,7 +12,7 @@ import Control.Monad.ST (ST)
 
 import Data.Functor.Contravariant
 import Data.Functor.Contravariant.Compose
-
+import Data.Monoid (Endo(Endo))
 
 
 
@@ -92,7 +92,8 @@ instance Arrow arr => Invariant2 (WrappedArrow arr) where
   invmap2 _ f' g _ (WrapArrow x) = WrapArrow $ arr g Cat.. x Cat.. arr f'
 
 
-
+instance Invariant Endo where
+  invmap f g (Endo x) = Endo (f . x . g)
 
 
 -- | from the @contravariant@ package

--- a/invariant.cabal
+++ b/invariant.cabal
@@ -17,6 +17,6 @@ cabal-version: >= 1.6
 
 library
   build-depends: base >= 4 && < 5
-  build-depends: contravariant >= 0.1.2 && < 0.3
+  build-depends: contravariant >= 0.1.2 && < 2
 
   exposed-modules: Data.Functor.Invariant


### PR DESCRIPTION
This adds an `Invariant Endo` instance, which would be useful for me.

Also, I needed to bump the upper version bounds for `contravariant`, since the latest version (`1.3.1.1`) is much larger.
