### PR TITLE
Allow building with template-haskell-2.17.0.0 (GHC 9.0)

### DIFF
--- a/invariant.cabal
+++ b/invariant.cabal
@@ -76,3 +76,5 @@ test-suite spec
                      , template-haskell >= 2.4  && < 2.18
   build-tool-depends:  hspec-discover:hspec-discover
   ghc-options:         -Wall
+  if impl(ghc >= 8.6)
+    ghc-options:       -Wno-star-is-type

--- a/invariant.cabal
+++ b/invariant.cabal
@@ -52,8 +52,8 @@ library
                      , StateVar             >= 1.1    && < 2
                      , stm                  >= 2.2    && < 3
                      , tagged               >= 0.7.3  && < 1
-                     , template-haskell     >= 2.4    && < 2.17
-                     , th-abstraction       >= 0.3    && < 0.4
+                     , template-haskell     >= 2.4    && < 2.18
+                     , th-abstraction       >= 0.4    && < 0.5
                      , transformers         >= 0.2    && < 0.6
                      , transformers-compat  >= 0.3    && < 1
                      , unordered-containers >= 0.2.4  && < 0.3
@@ -73,6 +73,6 @@ test-suite spec
                      , hspec            >= 1.8
                      , invariant
                      , QuickCheck       >= 2.11 && < 3
-                     , template-haskell >= 2.4  && < 2.17
+                     , template-haskell >= 2.4  && < 2.18
   build-tool-depends:  hspec-discover:hspec-discover
   ghc-options:         -Wall

--- a/src/Data/Functor/Invariant/TH.hs
+++ b/src/Data/Functor/Invariant/TH.hs
@@ -41,6 +41,7 @@ import qualified Data.Map as Map ((!), fromList, keys, lookup, member, size)
 import           Data.Maybe
 
 import           Language.Haskell.TH.Datatype
+import           Language.Haskell.TH.Datatype.TyVarBndr
 import           Language.Haskell.TH.Lib
 import           Language.Haskell.TH.Ppr
 import           Language.Haskell.TH.Syntax
@@ -729,7 +730,7 @@ data FFoldType a      -- Describes how to fold over a Type in a functor like way
           --   respectively.
         , ft_bad_app :: a
           -- ^ Type app, variable other than in last arguments
-        , ft_forall  :: [TyVarBndr] -> a -> a
+        , ft_forall  :: [TyVarBndrSpec] -> a -> a
           -- ^ Forall type
      }
 


### PR DESCRIPTION
This involves using `th-abstraction-0.4` or later.