### PR TITLE
Loosen constraint on Kleisli

### DIFF
--- a/src/Data/Functor/Invariant.hs
+++ b/src/Data/Functor/Invariant.hs
@@ -112,7 +112,7 @@ import           Data.Bifunctor.Tannen
 import           Data.Bifunctor.Wrapped
 
 -- comonad
-import           Control.Comonad (Comonad(..), Cokleisli(..), liftW)
+import           Control.Comonad (Cokleisli(..))
 
 -- containers
 import           Data.IntMap (IntMap)
@@ -739,9 +739,8 @@ instance Bifunctor p => Invariant2 (WrappedBifunctor p) where
   invmap2 = invmap2Bifunctor
 
 -- | from the @comonad@ package
-instance Comonad w => Invariant2 (Cokleisli w) where
-   invmap2 _ f' g _ (Cokleisli w) = Cokleisli $ g . w . liftW f'
-
+instance Invariant w => Invariant2 (Cokleisli w) where
+   invmap2 f f' g _ (Cokleisli w) = Cokleisli $ g . w . invmap f' f
 -- | from the @contravariant@ package
 instance Invariant2 Op where
   invmap2 f f' g g' (Op x) = Op $ invmap2 g g' f f' x

--- a/src/Data/Functor/Invariant.hs
+++ b/src/Data/Functor/Invariant.hs
@@ -702,8 +702,8 @@ instance Arrow arr => Invariant2 (App.WrappedArrow arr) where
   invmap2 _ f' g _ (App.WrapArrow x) = App.WrapArrow $ arr g Cat.. x Cat.. arr f'
 
 -- | from "Control.Arrow"
-instance Monad m => Invariant2 (Kleisli m) where
-  invmap2 _ f' g _ (Kleisli m) = Kleisli $ liftM g . m . f'
+instance Invariant m => Invariant2 (Kleisli m) where
+  invmap2 _ f' g g' (Kleisli m) = Kleisli $ invmap g g' . m . f'
 
 -- | from "Data.Semigroup"
 instance Invariant2 Arg where

--- a/src/Data/Functor/Invariant.hs
+++ b/src/Data/Functor/Invariant.hs
@@ -247,8 +247,8 @@ instance
   => Invariant (ArrowMonad a) where
   invmap f _ (ArrowMonad m) = ArrowMonad (m >>> arr f)
 -- | from "Control.Arrow"
-instance Monad m => Invariant (Kleisli m a) where
-  invmap = invmap2 id id
+instance Invariant m => Invariant (Kleisli m a) where
+  invmap f g (Kleisli m) = Kleisli (invmap f g . m)
 
 -- | from "Control.Exception"
 instance Invariant Handler where


### PR DESCRIPTION
`Invariant` instead of `Monad`, because `Kleisli` can be used when `m` is not a monad.